### PR TITLE
Add environment mapping for two flags

### DIFF
--- a/.changelogs/unreleased/25-flag-environment-variables-iQRKNypZ
+++ b/.changelogs/unreleased/25-flag-environment-variables-iQRKNypZ
@@ -1,0 +1,3 @@
+title: Add environment variable mapping for the '--ignore-repo' and '--deprecation-notice'
+  flags
+type: 0


### PR DESCRIPTION
The following two flags can now be configured/ set with an environment variables named `HELM_WHATUP_<FLAG_NAME>`:
    * --deprecation-notice
    * --ignore-repo

Closes #25